### PR TITLE
Add types to JavaScript code via JSDoc

### DIFF
--- a/app-ui/package.json
+++ b/app-ui/package.json
@@ -16,5 +16,6 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.2.3",
     "vite": "^4.4.6"
-  }
+  },
+  "prettier": {}
 }

--- a/app-ui/src/components/EventCard.vue
+++ b/app-ui/src/components/EventCard.vue
@@ -1,34 +1,41 @@
 <script setup>
-defineProps(['item']);
+defineProps({
+  item: {
+    /** @type import("vue").PropType<import("../types").SearchResult> */
+    type: Object,
+    required: true,
+  },
+});
 
 import dayjs from "dayjs";
-import Card from 'primevue/card';
+import Card from "primevue/card";
 
 // XXX - I would have thought dayjs would do day-of-week names.
-const dayNames = [
-    "Sun",
-    "Mon",
-    "Tue",
-    "Wed",
-    "Thu",
-    "Fri",
-    "Sat"
-]
+const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
+/**
+ * @param {dayjs.Dayjs} t
+ */
 function formatDate(t) {
   return dayNames[t.day()] + ", " + t.format("MMM D");
 }
 
+/**
+ *
+ * @param {import("../types").Time} time
+ */
 function formatTime(time) {
+  // @ts-ignore
   const t0 = dayjs.unix(parseInt(time.start));
   const start_date = formatDate(t0);
   const start_time = t0.format("h:mm a");
-  const start = `${start_date}, ${start_time}`
+  const start = `${start_date}, ${start_time}`;
 
-  if (! time.end) {
+  if (!time.end) {
     return start;
   }
 
+  // @ts-ignore
   const t1 = dayjs.unix(parseInt(time.end));
   const end_date = formatDate(t1);
   const end_time = t1.format("h:mm a");
@@ -55,9 +62,22 @@ function formatTime(time) {
 </template>
 
 <style scoped>
-fieldset { display: block; width: 100%; clear: both; }
-fieldset span { white-space: nowrap; }
-label { padding-left: 5px; padding-right: 1.0em; }
-.p-card div.p-card-content { padding: 0;  }  /*this isn't working*/
-.clear { break-before: left; } /*this isn't working*/
+fieldset {
+  display: block;
+  width: 100%;
+  clear: both;
+}
+fieldset span {
+  white-space: nowrap;
+}
+label {
+  padding-left: 5px;
+  padding-right: 1em;
+}
+.p-card div.p-card-content {
+  padding: 0;
+} /*this isn't working*/
+.clear {
+  break-before: left;
+} /*this isn't working*/
 </style>

--- a/app-ui/src/components/SearchMain.vue
+++ b/app-ui/src/components/SearchMain.vue
@@ -1,22 +1,23 @@
 <script setup>
-import {ref} from 'vue';
+import { ref } from "vue";
 
-import Button from 'primevue/button';
-import Checkbox from 'primevue/checkbox';
-import Fieldset from 'primevue/fieldset';
-import InputText from 'primevue/inputtext';
-import Listbox from 'primevue/listbox';
-import Panel from 'primevue/panel';
-import SelectButton from 'primevue/selectbutton';
+import Button from "primevue/button";
+import Checkbox from "primevue/checkbox";
+import Fieldset from "primevue/fieldset";
+import InputText from "primevue/inputtext";
+import Listbox from "primevue/listbox";
+import Panel from "primevue/panel";
+import SelectButton from "primevue/selectbutton";
 
-import SearchResults from './SearchResults.vue';
+import SearchResults from "./SearchResults.vue";
 
 // Base URL of the backend API
-const BASE_URL = import.meta.env.VITE_API_BASE_URL
+const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
-
-/*
+/**
  * Perform a call to the backend service. Catches errors, returns content body.
+ * @param {string} url
+ * @param {RequestInit} request
  */
 async function retrieveFromBackend(url, request) {
   try {
@@ -24,7 +25,10 @@ async function retrieveFromBackend(url, request) {
     if (response.ok) {
       return response.json();
     }
-    const error = new Error(response.statusText);
+
+    const error = /** @type {Error & { json: any }} */ (
+      new Error(response.statusText)
+    );
     error.json = response.json();
     throw error;
   } catch (error) {
@@ -33,22 +37,27 @@ async function retrieveFromBackend(url, request) {
   }
 }
 
-// The search criteria being selected
-const searchCriteria = ref({
-  days: [],
-  times: [],
-  locations: [],
-  age: null,
-  tags: [],
-  searchText: null
-});
+/**
+ * The search criteria being selected
+ */
+const searchCriteria = ref(
+  /** @type {import("../types").SearchCriteria} */ ({
+    days: [],
+    times: [],
+    locations: [],
+    age: null,
+    tags: [],
+    searchText: null,
+  })
+);
 
 // Snapshot of the search criteria, at the time the search is initiated
 // This is done so we can re-use the criteria to paginate through the results
-let currentSearchCriteria = {};
+let currentSearchCriteria =
+  /** @type {import("../types").SearchCriteria} */ ({});
 
 // The results of the most recent search query
-const searchResults = ref({});
+const searchResults = ref(/** @type {import("../types").SearchResults} */ ({}));
 
 /**
  * Action performed when search is requested.
@@ -63,6 +72,7 @@ function performSearch() {
 
 /**
  * Action performed to paginate through results for current search.
+ * @param {number} pageNum
  */
 async function goToResultsPage(pageNum) {
   console.log("currentSearchCriteria = ", currentSearchCriteria);
@@ -70,16 +80,19 @@ async function goToResultsPage(pageNum) {
     method: "POST",
     body: JSON.stringify(currentSearchCriteria),
     headers: {
-      "Content-type": "application/json; charset=UTF-8"
-    }
+      "Content-type": "application/json; charset=UTF-8",
+    },
   };
-  const response = await retrieveFromBackend(`/calendarEvent/search?pageNum=${pageNum}`, request);
+  const response = await retrieveFromBackend(
+    `/calendarEvent/search?pageNum=${pageNum}`,
+    request
+  );
   searchResults.value = response;
 }
 
-
-/*
+/**
  * Action performed when search criteria reset is requested.
+ * @param {string} whut
  */
 function resetSearchCriteria(whut) {
   if (whut == "days" || whut == "all") {
@@ -92,7 +105,7 @@ function resetSearchCriteria(whut) {
     searchCriteria.value.locations = [];
   }
   if (whut == "age" || whut == "all") {
-    searchCriteria.value.ages = null;
+    searchCriteria.value.age = null;
   }
   if (whut == "tags" || whut == "all") {
     searchCriteria.value.tags = [];
@@ -102,115 +115,168 @@ function resetSearchCriteria(whut) {
   }
 }
 
-
-/*
+/**
  * On startup retrieve list of tags used.
+ * @type {import("vue").Ref<string[]>}
  */
 const allTags = ref([]);
 async function loadTags() {
-  const response = await retrieveFromBackend("/calendarEvent/tags", {method: "GET"});
+  const response = await retrieveFromBackend("/calendarEvent/tags", {
+    method: "GET",
+  });
   allTags.value = response;
 }
 loadTags();
-
 
 /*
  * TODO - These should be moved to the backend service, and fetched from there.
  */
 const criteriaSelections = {
   days: [
-    {key: "MON", label: "Mon"},
-    {key: "TUE", label: "Tue"},
-    {key: "WED", label: "Wed"},
-    {key: "THU", label: "Thu"},
-    {key: "FRI", label: "Fri"},
-    {key: "SAT", label: "Sat"},
-    {key: "WEEKDAY", label: "Weekday"},
-    {key: "WEEKEND", label: "Weekend"},
+    { key: "MON", label: "Mon" },
+    { key: "TUE", label: "Tue" },
+    { key: "WED", label: "Wed" },
+    { key: "THU", label: "Thu" },
+    { key: "FRI", label: "Fri" },
+    { key: "SAT", label: "Sat" },
+    { key: "WEEKDAY", label: "Weekday" },
+    { key: "WEEKEND", label: "Weekend" },
   ],
   times: [
-    {key: "MORNING", label: "Morning"},
-    {key: "AFTERNOON", label: "Afternoon"},
-    {key: "EVENING", label: "Evening"}
+    { key: "MORNING", label: "Morning" },
+    { key: "AFTERNOON", label: "Afternoon" },
+    { key: "EVENING", label: "Evening" },
   ],
   locations: [
-    {key: "ACB", label: "Carver"},
-    {key: "ACE", label: "Central"},
-    {key: "ACP", label: "Cepeda"},
-    {key: "AOK", label: "Hampton at Oak Hill"},
-    {key: "AHC", label: "History Center"},
-    {key: "AHO", label: "Howson"},
-    {key: "ALW", label: "Little Walnut"},
-    {key: "AMR", label: "Manchaca Road"},
-    {key: "AMI", label: "Milwood"},
-    {key: "ANV", label: "North Village"},
-    {key: "AOQ", label: "Old Quarry"},
-    {key: "APH", label: "Pleasant Hill"},
-    {key: "ARR", label: "Recycled Reads"},
-    {key: "ARZ", label: "Ruiz"},
-    {key: "ASE", label: "Southeast"},
-    {key: "ASR", label: "Spicewood Springs"},
-    {key: "ASJ", label: "St. John"},
-    {key: "ATB", label: "Terrazas"},
-    {key: "ATO", label: "Twin Oaks"},
-    {key: "AUH", label: "University Hills"},
-    {key: "AWK", label: "Willie Mae Kirk"},
-    {key: "AWP", label: "Windsor Park"},
-    {key: "AYB", label: "Yarborough"}
+    { key: "ACB", label: "Carver" },
+    { key: "ACE", label: "Central" },
+    { key: "ACP", label: "Cepeda" },
+    { key: "AOK", label: "Hampton at Oak Hill" },
+    { key: "AHC", label: "History Center" },
+    { key: "AHO", label: "Howson" },
+    { key: "ALW", label: "Little Walnut" },
+    { key: "AMR", label: "Manchaca Road" },
+    { key: "AMI", label: "Milwood" },
+    { key: "ANV", label: "North Village" },
+    { key: "AOQ", label: "Old Quarry" },
+    { key: "APH", label: "Pleasant Hill" },
+    { key: "ARR", label: "Recycled Reads" },
+    { key: "ARZ", label: "Ruiz" },
+    { key: "ASE", label: "Southeast" },
+    { key: "ASR", label: "Spicewood Springs" },
+    { key: "ASJ", label: "St. John" },
+    { key: "ATB", label: "Terrazas" },
+    { key: "ATO", label: "Twin Oaks" },
+    { key: "AUH", label: "University Hills" },
+    { key: "AWK", label: "Willie Mae Kirk" },
+    { key: "AWP", label: "Windsor Park" },
+    { key: "AYB", label: "Yarborough" },
   ],
   ages: [
-    {key: "INFANT", label: "Infant (1 year and below)"},
-    {key: "TODDLER", label: "Toddler (ages 1-3)"},
-    {key: "PRESCHOOLER", label: "Preschooler (ages 3-5)"},
-    {key: "CHILD", label: "Child (ages 6-8)"},
-    {key: "PRETEEN", label: "Preteen (ages 9-11)"},
-    {key: "YOUNG_TEEN", label: "Young Teen (ages 12-14)"},
-    {key: "TEEN", label: "Teen (ages 15-17)"},
-    {key: "YOUNG_ADULT", label: "Young Adult (ages 18-21)"},
-    {key: "ADULT", label: "Adult (ages 21 and up)"},
-    {key: null, label: "All ages"}
-  ]
-}
-
+    { key: "INFANT", label: "Infant (1 year and below)" },
+    { key: "TODDLER", label: "Toddler (ages 1-3)" },
+    { key: "PRESCHOOLER", label: "Preschooler (ages 3-5)" },
+    { key: "CHILD", label: "Child (ages 6-8)" },
+    { key: "PRETEEN", label: "Preteen (ages 9-11)" },
+    { key: "YOUNG_TEEN", label: "Young Teen (ages 12-14)" },
+    { key: "TEEN", label: "Teen (ages 15-17)" },
+    { key: "YOUNG_ADULT", label: "Young Adult (ages 18-21)" },
+    { key: "ADULT", label: "Adult (ages 21 and up)" },
+    { key: null, label: "All ages" },
+  ],
+};
 </script>
 
 <template>
   <Panel header="Search for ...">
-
     <Fieldset legend="Day">
       <span v-for="day in criteriaSelections.days" :key="day.key">
-        <Checkbox name="criteria.days" v-model="searchCriteria.days" :inputId="day.key" :value="day.key" /><label :for="day.key">{{ day.label }}</label>
+        <Checkbox
+          name="criteria.days"
+          v-model="searchCriteria.days"
+          :inputId="day.key"
+          :value="day.key"
+        /><label :for="day.key">{{ day.label }}</label>
       </span>
       <br />
-      <Button class="clear" label="clear choices" link @click="resetSearchCriteria('days')" />
+      <Button
+        class="clear"
+        label="clear choices"
+        link
+        @click="resetSearchCriteria('days')"
+      />
     </Fieldset>
 
     <Fieldset legend="Time">
       <span v-for="time in criteriaSelections.times" :key="time.key">
-        <Checkbox name="criteria.times" v-model="searchCriteria.times" :inputId="time.key" :value="time.key" /><label :for="time.key">{{ time.label }}</label>
+        <Checkbox
+          name="criteria.times"
+          v-model="searchCriteria.times"
+          :inputId="time.key"
+          :value="time.key"
+        /><label :for="time.key">{{ time.label }}</label>
       </span>
       <br />
-      <Button class="clear" label="clear choices" link @click="resetSearchCriteria('times')" />
+      <Button
+        class="clear"
+        label="clear choices"
+        link
+        @click="resetSearchCriteria('times')"
+      />
     </Fieldset>
 
     <Fieldset legend="Location">
-      <span v-for="location in criteriaSelections.locations" :key="location.key">
-        <Checkbox name="criteria.locations" v-model="searchCriteria.locations" :inputId="location.key" :value="location.key" /><label :for="location.key">{{ location.label }}</label>
+      <span
+        v-for="location in criteriaSelections.locations"
+        :key="location.key"
+      >
+        <Checkbox
+          name="criteria.locations"
+          v-model="searchCriteria.locations"
+          :inputId="location.key"
+          :value="location.key"
+        /><label :for="location.key">{{ location.label }}</label>
       </span>
       <br />
-      <Button class="clear" label="clear choices" link @click="resetSearchCriteria('locations')" />
+      <Button
+        class="clear"
+        label="clear choices"
+        link
+        @click="resetSearchCriteria('locations')"
+      />
     </Fieldset>
 
     <Fieldset legend="Age">
-      <i class="pi pi-exclamation-triangle" style="color: black; background: yellow; padding: 3px" title='Warning! The "age" criteria currently is not reliable, due to source data issues.'></i>
-      <SelectButton v-model="searchCriteria.age" :options="criteriaSelections.ages" optionLabel="label" optionValue="key" aria-labelledby="basic" />
-<!--      <Button class="clear" label="clear choices" link @click="resetSearchCriteria('age')" />-->
+      <i
+        class="pi pi-exclamation-triangle"
+        style="color: black; background: yellow; padding: 3px"
+        title='Warning! The "age" criteria currently is not reliable, due to source data issues.'
+      ></i>
+      <SelectButton
+        v-model="searchCriteria.age"
+        :options="criteriaSelections.ages"
+        optionLabel="label"
+        optionValue="key"
+        aria-labelledby="basic"
+      />
+      <!--      <Button class="clear" label="clear choices" link @click="resetSearchCriteria('age')" />-->
     </Fieldset>
 
     <Fieldset legend="Tags">
-      <Listbox name="criterial.tags" v-model="searchCriteria.tags" :options="allTags" multiple
-               :virtualScrollerOptions="{ itemSize: 38 }" listStyle="height:250px" />
-      <Button class="clear" label="clear choices" link @click="resetSearchCriteria('tags')" />
+      <Listbox
+        name="criterial.tags"
+        v-model="searchCriteria.tags"
+        :options="allTags"
+        multiple
+        :virtualScrollerOptions="{ itemSize: 38 }"
+        listStyle="height:250px"
+      />
+      <Button
+        class="clear"
+        label="clear choices"
+        link
+        @click="resetSearchCriteria('tags')"
+      />
     </Fieldset>
 
     <Fieldset legend="Words or phrases to find">
@@ -219,21 +285,40 @@ const criteriaSelections = {
 
     <div>
       <Button label="Search!" @click="performSearch()" />
-      <Button class="clear" label="clear all choices" link @click="resetSearchCriteria('all')" />
+      <Button
+        class="clear"
+        label="clear all choices"
+        link
+        @click="resetSearchCriteria('all')"
+      />
     </div>
-
   </Panel>
 
   <Panel header="Events found ...">
-    <SearchResults :searchResults="searchResults" @go-to-results-page="(n) => goToResultsPage(n)" />
+    <SearchResults
+      :searchResults="searchResults"
+      @go-to-results-page="(n) => goToResultsPage(n)"
+    />
   </Panel>
-
 </template>
 
 <style scoped>
-fieldset { display: block; width: 100%; clear: both; }
-fieldset span { white-space: nowrap; }
-label { padding-left: 5px; padding-right: 1.0em; }
-.p-card div.p-card-content { padding: 0;  }  /*this isn't working*/
-.clear { break-before: left; } /*this isn't working*/
+fieldset {
+  display: block;
+  width: 100%;
+  clear: both;
+}
+fieldset span {
+  white-space: nowrap;
+}
+label {
+  padding-left: 5px;
+  padding-right: 1em;
+}
+.p-card div.p-card-content {
+  padding: 0;
+} /*this isn't working*/
+.clear {
+  break-before: left;
+} /*this isn't working*/
 </style>

--- a/app-ui/src/components/SearchResults.vue
+++ b/app-ui/src/components/SearchResults.vue
@@ -1,10 +1,17 @@
 <script setup>
-  defineProps(['searchResults']);
-  import EventCard from "./EventCard.vue";
+defineProps({
+  searchResults: {
+    /** @type import("vue").PropType<import("../types").SearchResults> */
+    type: Object,
+    required: true,
+  },
+});
+
+import EventCard from "./EventCard.vue";
 </script>
 
 <template>
-  <div v-if="! searchResults.results" >
+  <div v-if="!searchResults.results">
     <p style="text-align: center; margin-top: 8px">
       Results will appear here when you do a search.
     </p>
@@ -18,17 +25,30 @@
     <EventCard v-for="item in searchResults.results" :item="item" />
     <p style="text-align: center; margin-top: 8px">
       <span v-if="searchResults.prevPage !== null">
-        <i class="pi pi-angle-double-left pager-link-active" @click="$emit('go-to-results-page', searchResults.firstPage)"></i>
-        <i class="pi pi-angle-left pager-link-active" @click="$emit('go-to-results-page', searchResults.prevPage)"></i>
+        <i
+          class="pi pi-angle-double-left pager-link-active"
+          @click="$emit('go-to-results-page', searchResults.firstPage)"
+        ></i>
+        <i
+          class="pi pi-angle-left pager-link-active"
+          @click="$emit('go-to-results-page', searchResults.prevPage)"
+        ></i>
       </span>
       <span v-else>
         <i class="pi pi-angle-double-left pager-link-inactive"></i>
         <i class="pi pi-angle-left pager-link-inactive"></i>
       </span>
-      {{ searchResults.firstResult+1 }} to {{ searchResults.lastResult+1 }} of {{ searchResults.numResults }}
+      {{ searchResults.firstResult + 1 }} to
+      {{ searchResults.lastResult + 1 }} of {{ searchResults.numResults }}
       <span v-if="searchResults.nextPage !== null">
-        <i class="pi pi-angle-right pager-link-active" @click="$emit('go-to-results-page', searchResults.nextPage)"></i>
-        <i class="pi pi-angle-double-right pager-link-active" @click="$emit('go-to-results-page', searchResults.lastPage)"></i>
+        <i
+          class="pi pi-angle-right pager-link-active"
+          @click="$emit('go-to-results-page', searchResults.nextPage)"
+        ></i>
+        <i
+          class="pi pi-angle-double-right pager-link-active"
+          @click="$emit('go-to-results-page', searchResults.lastPage)"
+        ></i>
       </span>
       <span v-else>
         <i class="pi pi-angle-right pager-link-inactive"></i>

--- a/app-ui/src/main.js
+++ b/app-ui/src/main.js
@@ -1,11 +1,12 @@
-import './assets/main.css';
+/// <reference types="vite/client" />
+import "./assets/main.css";
 import "primevue/resources/themes/lara-light-indigo/theme.css";
-import 'primeicons/primeicons.css'
+import "primeicons/primeicons.css";
 
-import { createApp } from 'vue'
-import App from './App.vue';
-import PrimeVue from 'primevue/config';
+import { createApp } from "vue";
+import App from "./App.vue";
+import PrimeVue from "primevue/config";
 
-const app = createApp(App)
+const app = createApp(App);
 app.use(PrimeVue);
-app.mount('#app')
+app.mount("#app");

--- a/app-ui/src/types.d.ts
+++ b/app-ui/src/types.d.ts
@@ -1,0 +1,97 @@
+/** @todo Generate this file using the backend Swagger definition */
+
+export interface SearchResults {
+  currPage: number;
+  firstPage: number;
+  firstResult: number;
+  lastPage: number;
+  lastResult: number;
+  nextPage: number;
+  numPages: number;
+  numResults: number;
+  prevPage: number | null;
+  results: SearchResult[];
+  resultsPerPage: number;
+}
+
+export interface SearchResult {
+  content: string;
+  description: string;
+  isDeleted: boolean;
+  isFree: boolean;
+  location: { detail: string; key: string };
+  recommendedAge: { maxYears: number | null; minYears: number | null } | null;
+  registrationUrl: string | null;
+  subTitle: string | null;
+  summary: string;
+  tags: string[];
+  time: Time;
+  timestamp: number;
+  title: string;
+  url: string;
+}
+
+export interface Time {
+  start: number;
+  end: number;
+  localDayOfWeek: string;
+  localHourOfDay: number;
+}
+
+export type SearchDay =
+  | "MON"
+  | "TUE"
+  | "WED"
+  | "THU"
+  | "FRI"
+  | "SAT"
+  | "WEEKDAY"
+  | "WEEKEND";
+
+export type SearchTime = "MORNING" | "AFTERNOON" | "EVENING";
+
+export type SearchLocation =
+  | "ACB"
+  | "ACE"
+  | "ACP"
+  | "AOK"
+  | "AHC"
+  | "AHO"
+  | "ALW"
+  | "AMR"
+  | "AMI"
+  | "ANV"
+  | "AOQ"
+  | "APH"
+  | "ARR"
+  | "ARZ"
+  | "ASE"
+  | "ASR"
+  | "ASJ"
+  | "ATB"
+  | "ATO"
+  | "AUH"
+  | "AWK"
+  | "AWP"
+  | "AYB";
+
+export type SearchAge =
+  | "INFANT"
+  | "TODDLER"
+  | "PRESCHOOLER"
+  | "CHILD"
+  | "PRETEEN"
+  | "YOUNG_TEEN"
+  | "TEEN"
+  | "YOUNG_ADULT"
+  | "ADULT"
+  | null;
+
+export interface SearchCriteria {
+  days: SearchDay[];
+  times: SearchTime[];
+  locations: SearchLocation[];
+  age: SearchAge;
+  tags: string[];
+  searchText: string | null;
+}

--- a/app-ui/tsconfig.json
+++ b/app-ui/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": true,
+    "target": "ES2022",
+    "moduleResolution": "Bundler",
+    "module": "ES2022"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
This PR adds the necessary configuration files and documentation comments to add type safety to all of the frontend JavaScript code via [JSDoc](https://jsdoc.app/) and the [TypeScript language server](https://code.visualstudio.com/docs/languages/javascript) in your IDE. 

This requires no new build steps for the app itself, though it opens the door to stronger linting of the front end, if that was something we wanted to incorporate into the build process in the future.

The one caveat here is the `/src/types.d.ts` [ambient declaration file](https://microsoft.github.io/TypeScript-New-Handbook/chapters/type-declarations/) is currently handwritten. Preferably, this would be generated via the Swagger definition from the backend, but I don't know if that should block this PR as it could be an easy follow-on enhancement PR next.